### PR TITLE
Skip default values

### DIFF
--- a/juju_deployerizer/cli.py
+++ b/juju_deployerizer/cli.py
@@ -56,7 +56,7 @@ class Service:
         config = load_yaml("juju get %s" % self.name)
         options = {}
         for k, v in config.get('settings').items():
-            if 'value' in v:
+            if 'value' in v and not v.get('default', False):
                 options[k] = v['value']
         return options
 


### PR DESCRIPTION
To produce simpler configs this patch skips the config values that
are using the default value of the charm

Without this patch:

```
lxc:
  relations: []
  services:
    mysql:
      charm: cs:trusty/mysql
      num_units: 1
      options:
        backup_dir: /var/lib/mysql/backups
        backup_retention_count: 7
        backup_schedule: ''
        bind-address: 0.0.0.0
        binlog-format: MIXED
        block-size: 5
        ceph-osd-replication-count: 3
        dataset-size: 80%
        flavor: distro
        ha-bindiface: eth0
        ha-mcastport: 5411
        max-connections: -1
        nagios_context: juju
        prefer-ipv6: false
        preferred-storage-engine: InnoDB
        query-cache-size: 0
        query-cache-type: 'OFF'
        rbd-name: mysql1
        tuning-level: safest
        vip: ''
        vip_cidr: 24
        vip_iface: eth0
        wait-timeout: -1
```

With this patch:

```
lxc:
  relations: []
  services:
    mysql:
      charm: cs:trusty/mysql
      num_units: 1
```
